### PR TITLE
Fix settings configuration (and Redmine 3.4 compatibility)

### DIFF
--- a/app/views/subtasks_inherited_fields/_subtasks_inherited_fields.html.erb
+++ b/app/views/subtasks_inherited_fields/_subtasks_inherited_fields.html.erb
@@ -2,70 +2,70 @@
 
 <p>  
   <label><%= l(:inherit_fixed_version) %></label>
-  <%= check_box_tag 'settings[inherit_fixed_version_id]', 1, @settings[:inherit_fixed_version_id] %>
+  <%= check_box_tag 'settings[inherit_fixed_version_id]', 1, @settings['inherit_fixed_version_id'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_assigned_to) %></label>
-  <%= check_box_tag 'settings[inherit_assigned_to_id]', 1, @settings[:inherit_assigned_to_id] %>
+  <%= check_box_tag 'settings[inherit_assigned_to_id]', 1, @settings['inherit_assigned_to_id'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_category) %></label>
-  <%= check_box_tag 'settings[inherit_category_id]', 1, @settings[:inherit_category_id] %>
+  <%= check_box_tag 'settings[inherit_category_id]', 1, @settings['inherit_category_id'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_priority) %></label>
-  <%= check_box_tag 'settings[inherit_priority_id]', 1, @settings[:inherit_priority_id] %>
+  <%= check_box_tag 'settings[inherit_priority_id]', 1, @settings['inherit_priority_id'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_status) %></label>
-  <%= check_box_tag 'settings[inherit_status_id]', 1, @settings[:inherit_status_id] %>
+  <%= check_box_tag 'settings[inherit_status_id]', 1, @settings['inherit_status_id'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_start_date) %></label>
-  <%= check_box_tag 'settings[inherit_start_date]', 1, @settings[:inherit_start_date] %>
+  <%= check_box_tag 'settings[inherit_start_date]', 1, @settings['inherit_start_date'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_due_date) %></label>
-  <%= check_box_tag 'settings[inherit_due_date]', 1, @settings[:inherit_due_date] %>
+  <%= check_box_tag 'settings[inherit_due_date]', 1, @settings['inherit_due_date'] %>
 </p>
 
 <p>  
   <label><%=  l(:inherit) + " " + l(:field_subject) %></label>
-  <%= check_box_tag 'settings[inherit_subject]', 1, @settings[:inherit_subject] %>
+  <%= check_box_tag 'settings[inherit_subject]', 1, @settings['inherit_subject'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_description) %></label>
-  <%= check_box_tag 'settings[inherit_description]', 1, @settings[:inherit_description] %>
+  <%= check_box_tag 'settings[inherit_description]', 1, @settings['inherit_description'] %>
 </p>
 
 <p>  
   <label><%= l(:inherit_is_private) %></label>
-  <%= check_box_tag 'settings[inherit_is_private]', 1, @settings[:inherit_is_private] %>
+  <%= check_box_tag 'settings[inherit_is_private]', 1, @settings['inherit_is_private'] %>
 </p>
 
-<% @settings[:inherit_custom_fields] ||= {} %>
+<% @settings['inherit_custom_fields'] ||= {} %>
 <% IssueCustomField.all.each do |field| %>
   <p>  
     <label><%= l(:inherit) + " " + field.name %></label>
-    <%= check_box_tag "settings[inherit_custom_fields][#{field.id}]", 1, @settings[:inherit_custom_fields][field.id.to_s] %>
+    <%= check_box_tag "settings[inherit_custom_fields][#{field.id}]", 1, @settings['inherit_custom_fields'][field.id.to_s] %>
   </p>
 <% end %>
 
 <p>  
   <label><%= l(:inherit_parent_tracker) %></label>
-  <%= check_box_tag 'settings[inherit_tracker_id]', 1, @settings[:inherit_tracker_id] %>
+  <%= check_box_tag 'settings[inherit_tracker_id]', 1, @settings['inherit_tracker_id'] %>
 </p>
 
 <p>  
   <label id="settings_default_tracker_id_label"><%= l(:default_subtask_tracker) %></label>
-  <%= select_tag "settings[default_tracker_id]", options_for_select(Tracker.all.map {|t| [t.name, t.id]},@settings[:default_tracker_id]) %>
+  <%= select_tag "settings[default_tracker_id]", options_for_select(Tracker.all.map {|t| [t.name, t.id]},@settings['default_tracker_id']) %>
 </p>
 
 

--- a/init.rb
+++ b/init.rb
@@ -6,22 +6,22 @@ Redmine::Plugin.register :redmine_subtasks_inherited_fields do
   url 'http://www.edosoftfactory.com'
   author_url 'mailto:david.verdu@edosoftfactory.com'
   
-  requires_redmine :version_or_higher => '3.0.0'  
+  requires_redmine version_or_higher: '3.0.0'
 
-  settings :default => {
-    :inherit_fixed_version_id => true,
-    :inherit_is_private => true,
-    :inherit_assigned_to_id => false,
-    :inherit_status_id => false,
-    :inherit_priority_id => false,
-    :inherit_start_date => false,
-    :inherit_due_date => false,
-    :inherit_subject => false,
-    :inherit_description => false,
-    :inherit_tracker_id => true,
-    :default_tracker_id => 0,
-    :inherit_category_id => false
-  }, :partial => 'subtasks_inherited_fields/subtasks_inherited_fields'
+  settings default: {
+      inherit_fixed_version_id: true,
+      inherit_is_private:       true,
+      inherit_assigned_to_id:   false,
+      inherit_status_id:        false,
+      inherit_priority_id:      false,
+      inherit_start_date:       false,
+      inherit_due_date:         false,
+      inherit_subject:          false,
+      inherit_description:      false,
+      inherit_tracker_id:       true,
+      default_tracker_id:       0,
+      inherit_category_id:      false
+  }, partial: 'subtasks_inherited_fields/subtasks_inherited_fields'
 
 end
 

--- a/lib/issues_controller_patch.rb
+++ b/lib/issues_controller_patch.rb
@@ -6,23 +6,24 @@ module SubtasksInheritedFields
       # Redirects user after a successful issue creation with inheritance
       def redirect_after_create_plugin
         if params[:continue]
+          url_params = {}
+          url_params[:issue] = {:tracker_id => @issue.tracker, :parent_issue_id => @issue.parent_issue_id}.reject {|k,v| v.nil?}
+          url_params[:back_url] = params[:back_url].presence
 
-          attrs = {:tracker_id => @issue.tracker, :parent_issue_id => @issue.parent_issue_id}.reject {|k,v| v.nil?}
-
-          #inherit fields on create subtask and continue
+          # inherit fields on create subtask and continue
           if @issue.parent_issue_id
             parent_issue = Issue.find(@issue.parent_issue_id)
-            attrs = SubtasksInheritedFields::Helpers.inherit_attrs(parent_issue)
+            url_params[:issue] = SubtasksInheritedFields::Helpers.inherit_attrs(parent_issue)
           end
 
           if params[:project_id]
-            redirect_to new_project_issue_path(@issue.project, :issue => attrs)
+            redirect_to new_project_issue_path(@issue.project, url_params)
           else
-            attrs.merge! :project_id => @issue.project_id
-            redirect_to new_issue_path(:issue => attrs)
+            url_params[:issue].merge! :project_id => @issue.project_id
+            redirect_to new_issue_path(url_params)
           end
         else
-          redirect_to issue_path(@issue)
+          redirect_back_or_default issue_path(@issue)
         end
       end
     end

--- a/lib/issues_helper_patch.rb
+++ b/lib/issues_helper_patch.rb
@@ -6,7 +6,7 @@ module SubtasksInheritedFields
       # Returns a link for adding a new subtask to the given issue
       def link_to_new_subtask_plugin(issue)
         attrs = SubtasksInheritedFields::Helpers.inherit_attrs(issue)
-        link_to(l(:button_add), new_project_issue_path(issue.project, :issue => attrs))
+        link_to(l(:button_add), new_project_issue_path(issue.project, :issue => attrs, :back_url => issue_path(issue)))
       end
     end
 

--- a/lib/subtasks_inherited_fields.rb
+++ b/lib/subtasks_inherited_fields.rb
@@ -6,27 +6,27 @@ module SubtasksInheritedFields
       settings = Setting.find_by_name("plugin_redmine_subtasks_inherited_fields") || {}
       settings = settings.value if settings.respond_to? :value
       settings = {} if settings == ""
-      if settings[:inherit_tracker_id] #inherit tracker
+      if settings['inherit_tracker_id'] #inherit tracker
         attrs[:tracker_id] = parent_issue.tracker
       else #use default subtask tracker
-        default_tracker = Tracker.find_by_id(settings[:default_tracker_id] || 0) || parent_issue.tracker
+        default_tracker = Tracker.find_by_id(settings['default_tracker_id'] || 0) || parent_issue.tracker
         project = parent_issue.project
         default_tracker = parent_issue.tracker unless project.trackers.include? default_tracker
         attrs[:tracker_id] = default_tracker
       end
-      attrs[:fixed_version_id] = parent_issue.fixed_version_id if settings[:inherit_fixed_version_id]
-      attrs[:category_id] = parent_issue.category_id if settings[:inherit_category_id]
-      attrs[:assigned_to_id] = parent_issue.assigned_to_id if settings[:inherit_assigned_to_id]
-      attrs[:priority_id] = parent_issue.priority_id if settings[:inherit_priority_id]
-      attrs[:start_date] = parent_issue.start_date if settings[:inherit_start_date]
-      attrs[:due_date] = parent_issue.due_date if settings[:inherit_due_date]
-      attrs[:subject] = parent_issue.subject if settings[:inherit_subject]
-      attrs[:description] = parent_issue.description if settings[:inherit_description]
-      attrs[:is_private] = parent_issue.is_private if settings[:inherit_is_private]
-      attrs[:status_id] = parent_issue.status_id if settings[:inherit_status_id]
+      attrs[:fixed_version_id] = parent_issue.fixed_version_id if settings['inherit_fixed_version_id']
+      attrs[:category_id]      = parent_issue.category_id if settings['inherit_category_id']
+      attrs[:assigned_to_id]   = parent_issue.assigned_to_id if settings['inherit_assigned_to_id']
+      attrs[:priority_id]      = parent_issue.priority_id if settings['inherit_priority_id']
+      attrs[:start_date]       = parent_issue.start_date if settings['inherit_start_date']
+      attrs[:due_date]         = parent_issue.due_date if settings['inherit_due_date']
+      attrs[:subject]          = parent_issue.subject if settings['inherit_subject']
+      attrs[:description]      = parent_issue.description if settings['inherit_description']
+      attrs[:is_private]       = parent_issue.is_private if settings['inherit_is_private']
+      attrs[:status_id]        = parent_issue.status_id if settings['inherit_status_id']
   
       #inherit custom fields
-      inherit_custom_fields = settings[:inherit_custom_fields] || {}
+      inherit_custom_fields = settings['inherit_custom_fields'] || {}
       unless inherit_custom_fields.empty?
         custom_field_values = {}
         parent_issue.custom_field_values.each do |v|


### PR DESCRIPTION
Access the settings hash with strings instead of symbols.

Also adapt the patches to the newer 3.4.x way